### PR TITLE
ci: add backend test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,18 @@ jobs:
         working-directory: web
       - uses: pre-commit/action@v3.0.1
 
+  test-api:
+    name: Test (API)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      - name: Install dependencies (API)
+        run: uv sync --directory api --dev
+      - name: Run tests
+        run: uv run pytest
+        working-directory: api
+
   check-web:
     name: Lint, format, and typecheck (web)
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds a `test-api` job to the CI workflow that runs `uv run pytest` on every push and pull request.

The existing CI badge in the README will reflect this job's status automatically.

Depends on #23 (tests must exist before CI can run them).

Closes #16

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added a `test-api` job to run pytest on the backend API code, configured to run on all pushes and pull requests alongside existing lint and typecheck jobs.

- New job follows the same structure as existing `check-api` job (uses `astral-sh/setup-uv@v5`, installs dependencies with `uv sync --directory api --dev`)
- Runs `uv run pytest` in the api working directory
- Will run in parallel with other CI jobs for faster feedback
- CI badge in README will automatically reflect this job's status

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no concerns
- The test job configuration is simple, well-structured, and follows established patterns from existing jobs in the workflow. No issues found.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yml | added `test-api` job that runs pytest on API code, follows existing patterns and is properly configured |

</details>



<sub>Last reviewed commit: 2f0e7e4</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->