### PR TITLE
fix: replace fixed 3s sleep with load event + 0.5s in get_md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,9 @@ librarian.config.json
 .claude/
 CLAUDE.md
 
+# Notebooks (local experiments, not committed)
+*.ipynb
+
 # Backup files
 *.bk
 *.orig

--- a/api/librarian/_tools.py
+++ b/api/librarian/_tools.py
@@ -80,8 +80,9 @@ async def get_md(path: str) -> str:
             }
         )
         page = await browser.new_page()
-        await page.goto(path, wait_until="commit")
-        await asyncio.sleep(3)
+        await page.goto(path, wait_until="load")
+        # Brief pause for JS to finish rendering content after the load event.
+        await asyncio.sleep(0.5)
         for frame in page.frames:
             try:
                 # force pdf.js to render all pages (see issue #2 for a more robust fix)


### PR DESCRIPTION
`wait_until="commit"` + `asyncio.sleep(3)` was fragile — slow pages could still be loading, fast pages wasted time. 

Switching to `wait_until="load"` (waits for HTML/CSS/images) + a 0.5s sleep for JS rendering. Most research sources are server-rendered so 0.5s is sufficient.

Also adds `*.ipynb` to `.gitignore`.

Closes #4

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Improved page loading reliability in `get_md()` by switching from `wait_until="commit"` to `wait_until="load"` and reducing sleep time from 3s to 0.5s.

- Replaced fragile timing approach that could fail on slow pages or waste time on fast pages
- `wait_until="load"` waits for HTML/CSS/images before proceeding (more robust than `"commit"`)
- 0.5s sleep is sufficient for JS rendering on server-rendered research sources
- Added `*.ipynb` to `.gitignore` for local notebook experiments

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no issues found
- The changes are well-reasoned and improve both reliability and performance. The switch to `wait_until="load"` is more robust than the previous `"commit"` approach, and the reduced sleep time (0.5s vs 3s) is appropriate for the stated use case of server-rendered pages. The `.gitignore` addition is standard practice. No logic, syntax, or security issues detected.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .gitignore | Added `*.ipynb` to ignore Jupyter notebooks - standard practice |
| api/librarian/_tools.py | Replaced fragile 3s fixed sleep with `wait_until="load"` + 0.5s for JS rendering - more reliable and efficient |

</details>



<sub>Last reviewed commit: 8d728c1</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->